### PR TITLE
feat: update to boto3[crt]==1.38.8 so that s3 multi region access point works

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 kubernetes==30.1.0
-boto3==1.37.24
+boto3[crt]==1.38.8
 glueops-helpers @ https://github.com/GlueOps/python-glueops-helpers-library/archive/refs/tags/v0.2.0.zip
 PyYAML==6.0.2


### PR DESCRIPTION
### **PR Type**
enhancement, dependencies


___

### **Description**
- Upgraded `boto3` dependency to version 1.38.8 with CRT support.

- Ensures compatibility with S3 multi-region access points.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>requirements.txt</strong><dd><code>Upgrade boto3 version and enable CRT support</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

requirements.txt

<li>Updated <code>boto3</code> from 1.37.24 to <code>boto3[crt]</code> 1.38.8.<br> <li> Added CRT extra for enhanced S3 multi-region access point support.


</details>


  </td>
  <td><a href="https://github.com/GlueOps/certs-backup-restore/pull/108/files#diff-4d7c51b1efe9043e44439a949dfd92e5827321b34082903477fd04876edb7552">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>