### PR TITLE
refactor for new backup strategy

### DIFF
--- a/restore/restore.py
+++ b/restore/restore.py
@@ -24,7 +24,7 @@ def get_latest_backup():
 
     paginator = s3.get_paginator("list_objects_v2")
     page_iterator = paginator.paginate(Bucket=bucket_name,Prefix=captain_domain+"/"+backup_prefix)
-    latest_snap_object = None
+    latest_snap_object = {}
     for page in page_iterator:
         if "Contents" in page:
             for obj in page['Contents']:

--- a/restore/restore.py
+++ b/restore/restore.py
@@ -37,7 +37,6 @@ def get_latest_backup():
                             obj_date = datetime.fromisoformat(tag['Value'])
                             break
                     
-                    # if the obj have a primary tag we should use it  
                     if obj['Key'].endswith('.snap') and obj['Key'] == restore_this_backup:
                         return obj
 

--- a/restore/restore.py
+++ b/restore/restore.py
@@ -43,7 +43,6 @@ def get_latest_backup():
                     if obj['Key'].endswith('.snap') and (not latest_snap_object or latest_snap_object['date'] < obj_date):
                         latest_snap_object['date'] = obj_date
                         latest_snap_object['obj'] = obj
-    return latest_snap_object['obj']
 
     if latest_snap_object:
         # Download the latest secrets.yaml file

--- a/restore/restore.py
+++ b/restore/restore.py
@@ -14,6 +14,7 @@ output_file = "secrets.yaml"
 bucket_name = os.getenv("BUCKET_NAME")
 captain_domain = os.getenv("CAPTAIN_DOMAIN")
 backup_prefix = os.getenv("BACKUP_PREFIX")
+restore_this_backup = os.getenv("RESTORE_THIS_BACKUP")
 
 #init child logger
 logger = logging.getLogger('CERT_BACKUP_RESTORE.config')
@@ -26,18 +27,30 @@ def get_latest_backup():
     latest_snap_object = None
     for page in page_iterator:
         if "Contents" in page:
-            snap_objects = [obj for obj in page['Contents'] if obj['Key'].endswith(output_file)]
-            if snap_objects:
-                current_latest_snap_object = max(snap_objects, key=lambda obj: obj['LastModified']) 
-            if (latest_snap_object is None or 
-                current_latest_snap_object['LastModified'] > latest_snap_object['LastModified']):
-                latest_snap_object = current_latest_snap_object
+            for obj in page['Contents']:
+                    response = client.get_object_tagging(
+                        Bucket=bucket_name,
+                        Key=f"{captain_domain}/{backup_prefix}/{obj['Key']}",
+                    )
+                    for tag in response['TagSet']:
+                        if tag['Key'] == "datetime":
+                            obj_date = datetime.fromisoformat(tag['Value'])
+                            break
+                    
+                    # if the obj have a primary tag we should use it  
+                    if obj['Key'].endswith('.snap') and obj['Key'] == restore_this_backup:
+                        return obj
+
+                    if obj['Key'].endswith('.snap') and (not latest_snap_object or latest_snap_object['date'] < obj_date):
+                        latest_snap_object['date'] = obj_date
+                        latest_snap_object['obj'] = obj
+    return latest_snap_object['obj']
 
     if latest_snap_object:
         # Download the latest secrets.yaml file
         local_file_path = os.path.join(output_file)
-        s3.download_file(bucket_name, latest_snap_object['Key'], local_file_path)
-        logger.info(f"Downloaded the latest backup from s3: {latest_snap_object['Key']}")
+        s3.download_file(bucket_name, latest_snap_object['obj']['Key'], local_file_path)
+        logger.info(f"Downloaded the latest backup from s3: {latest_snap_object['obj']['Key']}")
         return local_file_path
     else:
         logger.info("No secrets.yaml files found in the specified S3 location.")

--- a/restore/restore.py
+++ b/restore/restore.py
@@ -33,7 +33,7 @@ def get_latest_backup():
                         Key=f"{captain_domain}/{backup_prefix}/{obj['Key']}",
                     )
                     for tag in response['TagSet']:
-                        if tag['Key'] == "datetime":
+                        if tag['Key'] == "datetime_created":
                             obj_date = datetime.fromisoformat(tag['Value'])
                             break
                     


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Refactored backup selection logic to use `datetime_created` tag.

- Added support for restoring a specific backup via `RESTORE_THIS_BACKUP`.

- Improved handling of latest backup object retrieval.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>restore.py</strong><dd><code>Refactor backup retrieval and add targeted restore option</code></dd></summary>
<hr>

restore/restore.py

<li>Replaced backup selection logic to use <code>datetime_created</code> S3 tag.<br> <li> Added <code>RESTORE_THIS_BACKUP</code> env var to restore a specific backup.<br> <li> Changed structure of <code>latest_snap_object</code> to store date and object.<br> <li> Updated S3 download logic to use new object structure.


</details>


  </td>
  <td><a href="https://github.com/GlueOps/certs-backup-restore/pull/110/files#diff-3c46d57eeacc87266f1c50c261d805eb949423136d2eda01830230bb99d1051c">+21/-9</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>