### PR TITLE
fix: add exit() when error occurs

### DIFF
--- a/backup/backup.py
+++ b/backup/backup.py
@@ -55,5 +55,7 @@ def upload_secrets_to_s3():
         logger.info(f"File uploaded to S3: {bucket_name}/{s3_key}")
     except FileNotFoundError:
         logger.error(f"The file {output_file} was not found.")
+        exit(0)
     except Exception as e:
         logger.error(f"An error occurred: {str(e)}")
+        exit(0)

--- a/backup/backup.py
+++ b/backup/backup.py
@@ -18,8 +18,8 @@ logger = logging.getLogger('CERT_BACKUP_RESTORE.config')
 
 
 def handle_error_and_exit(msg):
-    logger.info(msg)
-    exit(0)
+    logger.error(msg)
+    exit(1)
 
 def get_tls_secrets():
     try:

--- a/backup/backup.py
+++ b/backup/backup.py
@@ -54,8 +54,6 @@ def upload_secrets_to_s3():
         s3.upload_file(output_file, bucket_name, s3_key)
         logger.info(f"File uploaded to S3: {bucket_name}/{s3_key}")
     except FileNotFoundError:
-        logger.error(f"The file {output_file} was not found.")
-        exit(0)
+        handle_error_and_exit(f"The file {output_file} was not found.")
     except Exception as e:
-        logger.error(f"An error occurred: {str(e)}")
-        exit(0)
+        handle_error_and_exit(f"An error occurred: {str(e)}")

--- a/backup/backup.py
+++ b/backup/backup.py
@@ -16,6 +16,11 @@ backup_prefix = os.getenv("BACKUP_PREFIX")
 #init child logger
 logger = logging.getLogger('CERT_BACKUP_RESTORE.config')
 
+
+def handle_error_and_exit(msg):
+    logger.info(msg)
+    exit(0)
+
 def get_tls_secrets():
     try:
         # Create a Kubernetes API client


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Replace error logging with immediate exit on error.

- Use `handle_error_and_exit` for critical error handling in S3 upload.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>backup.py</strong><dd><code>Use exit handler for S3 upload errors</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

backup/backup.py

<li>Replaced logger error calls with <code>handle_error_and_exit</code> for file not <br>found and generic exceptions.<br> <li> Ensures process exits immediately on critical upload errors.


</details>


  </td>
  <td><a href="https://github.com/GlueOps/certs-backup-restore/pull/114/files#diff-65c55499d3a0072b1b0556cdd38dbd4d5da32a1bab6dad4a3895c8de7fa23829">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>