### PR TITLE
fix: Update restore.py

### DIFF
--- a/restore/restore.py
+++ b/restore/restore.py
@@ -37,10 +37,10 @@ def get_latest_backup():
                         obj_date = datetime.fromisoformat(tag['Value'])
                         break
 
-                if obj['Key'].endswith('.snap') and os.path.basename(obj['Key']) == restore_this_backup:
+                if obj['Key'].endswith('.yaml') and os.path.basename(obj['Key']) == restore_this_backup:
                     logger.info(f"restoring this backup {restore_this_backup}")
                     return obj
-                if obj['Key'].endswith('.snap') and (not latest_snap_object or latest_snap_object['date'] < obj_date):
+                if obj['Key'].endswith('.yaml') and (not latest_snap_object or latest_snap_object['date'] < obj_date):
                     latest_snap_object['date'] = obj_date
                     latest_snap_object['obj'] = obj
 


### PR DESCRIPTION
### **User description**
possible fix for https://github.com/internal-GlueOps/issues/issues/202


___

### **PR Type**
Bug fix


___

### **Description**
• Fix file extension filter from `.snap` to `.yaml` in backup restoration
• Add missing newline at end of file


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>restore.py</strong><dd><code>Fix backup file extension filtering</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

restore/restore.py

• Changed file extension check from <code>.snap</code> to <code>.yaml</code> in two locations<br> • <br>Added missing newline at end of file


</details>


  </td>
  <td><a href="https://github.com/GlueOps/certs-backup-restore/pull/118/files#diff-3c46d57eeacc87266f1c50c261d805eb949423136d2eda01830230bb99d1051c">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>