### PR TITLE
fix: consider when old objects doesn't have custom defined tag 'datet…

### DIFF
--- a/restore/restore.py
+++ b/restore/restore.py
@@ -28,6 +28,7 @@ def get_latest_backup():
     for page in page_iterator:
         if "Contents" in page:
             for obj in page['Contents']:
+                obj_date = None
                 response = s3.get_object_tagging(
                     Bucket=bucket_name,
                     Key=obj['Key'],
@@ -40,7 +41,10 @@ def get_latest_backup():
                 if obj['Key'].endswith('.yaml') and os.path.basename(obj['Key']) == restore_this_backup:
                     logger.info(f"restoring this backup {restore_this_backup}")
                     return obj
-                  
+                
+                if obj_date is None:
+                    continue
+                
                 if obj['Key'].endswith('.yaml') and (not latest_snap_object or latest_snap_object['date'] < obj_date):
                     latest_snap_object['date'] = obj_date
                     latest_snap_object['obj'] = obj


### PR DESCRIPTION
### **User description**
…ime_created'


___

### **PR Type**
Bug fix


___

### **Description**
- Fix handling of backup objects without `datetime_created` tag

- Initialize `obj_date` variable and skip objects with missing tags

- Prevent crashes when processing legacy backup objects


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Backup Object"] --> B["Check datetime_created tag"]
  B --> C{"Tag exists?"}
  C -->|Yes| D["Parse date and process"]
  C -->|No| E["Skip object (continue)"]
  D --> F["Update latest backup if newer"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>restore.py</strong><dd><code>Handle missing datetime_created tag gracefully</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

restore/restore.py

<ul><li>Initialize <code>obj_date</code> variable to <code>None</code> before tag processing<br> <li> Add check to skip objects when <code>obj_date</code> is <code>None</code><br> <li> Prevent processing objects without <code>datetime_created</code> tag</ul>


</details>


  </td>
  <td><a href="https://github.com/GlueOps/certs-backup-restore/pull/127/files#diff-3c46d57eeacc87266f1c50c261d805eb949423136d2eda01830230bb99d1051c">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

