### PR TITLE
docs: correct env var names in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,25 @@ python main.py --restore
 
 ### Environment Variables
 
+**AWS credentials** are read from the standard boto3 credential chain. When using static
+keys, the variable names must be the ones boto3 recognizes (when running in-cluster with an
+IRSA / IAM role, these are not needed):
+
 ```bash
-BUCKET_NAME    ="your-s3-bucket-name"
-AWS_ACCESS_KEY ="your-aws-access-key"
-AWS_SECRET_KEY ="your-aws-secret-key"
-BUCKET_REGION  ="your-s3-bucket-region"
+AWS_ACCESS_KEY_ID     ="your-aws-access-key-id"
+AWS_SECRET_ACCESS_KEY ="your-aws-secret-access-key"
+AWS_REGION            ="your-s3-bucket-region"   # or AWS_DEFAULT_REGION
 ```
+
+**Application configuration:**
+
+```bash
+BUCKET_NAME        ="your-s3-bucket-name"   # required (backup + restore)
+CAPTAIN_DOMAIN     ="your-cluster-domain"   # required; first path segment of the S3 key
+BACKUP_PREFIX      ="tls-secrets"           # required; second path segment of the S3 key
+EXCLUDE_NAMESPACES ="kube-system,default"   # required for --restore; comma-separated
+RESTORE_THIS_BACKUP="secrets.yaml"          # optional (--restore); pin a specific backup file
+PYTHON_LOG_LEVEL   ="INFO"                  # optional; defaults to INFO
+```
+
+Backups are written to `s3://$BUCKET_NAME/$CAPTAIN_DOMAIN/$BACKUP_PREFIX/<YYYY-MM-DD>/secrets.yaml`.


### PR DESCRIPTION
The documented environment variables didn't match what the code and boto3 actually read.

### Fixes
- **`AWS_ACCESS_KEY` / `AWS_SECRET_KEY` → `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`** — boto3's default credential chain only recognizes the latter names; the documented ones were silently ignored.
- **`BUCKET_REGION` → `AWS_REGION`** — `BUCKET_REGION` is not referenced anywhere in the code; boto3 needs `AWS_REGION` (or `AWS_DEFAULT_REGION`).
- **Documented the app-specific vars the code actually requires** but that were missing from the README: `CAPTAIN_DOMAIN`, `BACKUP_PREFIX`, `EXCLUDE_NAMESPACES`, plus optional `RESTORE_THIS_BACKUP` and `PYTHON_LOG_LEVEL`.

Verified against `backup/backup.py`, `restore/restore.py`, and `main.py`. Docs-only change; no behavior change.