### PR TITLE
ci: use GITHUB_TOKEN for release-please and publish image in-run

### DIFF
--- a/.github/workflows/container_image.yaml
+++ b/.github/workflows/container_image.yaml
@@ -5,6 +5,13 @@ on:
     tags:
       - 'v*'
   workflow_dispatch:
+  workflow_call:
+    inputs:
+      version:
+        description: 'Release tag to also apply as an image tag (e.g. v2.3.2). Set when called from release-please.'
+        required: false
+        type: string
+        default: ''
 
 env:
   REGISTRY: ghcr.io
@@ -46,6 +53,7 @@ jobs:
             type=ref,event=tag,prefix=
             type=sha,format=short,prefix=
             type=sha,format=long,prefix=
+            type=raw,value=${{ inputs.version }},enable=${{ inputs.version != '' }}
       - name: Build and push Docker image
         id: build-and-push
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -13,12 +13,26 @@ permissions:
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    outputs:
+      release_created: ${{ steps.release.outputs.release_created }}
+      tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
-      # Uses CREATE_REPO_RELEASE (PAT) so that the tag/release created by
-      # release-please triggers the tag-based container_image.yaml build.
-      # Releases created with the default GITHUB_TOKEN do not trigger workflows.
-      - uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4.4.1
+      - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
+        id: release
         with:
-          token: ${{ secrets.CREATE_REPO_RELEASE }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+
+  # A tag/release created with GITHUB_TOKEN does not trigger other workflows,
+  # so the tag-based container_image.yaml will not fire on release. Instead we
+  # build/publish the image here, in the same run, when a release was cut.
+  publish-image:
+    needs: release-please
+    if: ${{ needs.release-please.outputs.release_created == 'true' }}
+    permissions:
+      contents: read
+      packages: write
+    uses: ./.github/workflows/container_image.yaml
+    with:
+      version: ${{ needs.release-please.outputs.tag_name }}


### PR DESCRIPTION
Fixes the release-please failure where opening the release PR errored with `Resource not accessible by personal access token` — the `CREATE_REPO_RELEASE` PAT had `contents: write` but not `pull-requests: write`.

## Change
Switch to the default **`GITHUB_TOKEN`** (granted `pull-requests: write` via the workflow `permissions` block), and bump the action to **v5.0.0** (also resolves Renovate #371; v5's only breaking change is Node 20→24, runner-only).

## The catch this handles
A tag/release created with `GITHUB_TOKEN` **does not trigger other workflows**, so the tag-based `container_image.yaml` would no longer fire on release — that's the exact reason the original setup used a PAT.

To keep the image publishing, the build now runs **inside the release-please run**, gated on `release_created`:
- `release-please` job exposes `release_created` + `tag_name` outputs.
- new `publish-image` job calls `container_image.yaml` as a **reusable workflow** (`workflow_call`) when a release is cut, passing the tag as `version`.
- `container_image.yaml` gains a `workflow_call` trigger + `version` input and tags the image `vX.Y.Z` via `type=raw`. Its `push: tags: ['v*']` and `workflow_dispatch` triggers are unchanged, so manual tag pushes still work.

Because the release commit is the head of `main` when the release PR merges, `github.sha` already points at the tagged commit, so the `sha` image tags remain correct.

## Heads-up: branch protection
PRs opened by `GITHUB_TOKEN` do **not** trigger `on: pull_request` workflows. If `main`'s branch protection requires status checks, the release PR may need an admin merge (or a PAT/App token). No required PR checks exist here today, so this should merge normally.