### PR TITLE
fix: authenticate release-please via GitHub App token

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -17,10 +17,16 @@ jobs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        id: app-token
+        with:
+          app-id: ${{ secrets.RELEASE_PLEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_PLEASE_APP_PRIVATE_KEY }}
+
       - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         id: release
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 


### PR DESCRIPTION
Switches release-please to authenticate with the **GitHub App** (`public-release-please`) via `actions/create-github-app-token`, instead of `GITHUB_TOKEN`/`CREATE_REPO_RELEASE`. Matches the setup in `tools-github-app-creator-for-development`.

**Why:** App installation tokens trigger downstream workflows (unlike `GITHUB_TOKEN`) and let release PRs run required checks (no admin merge). The release-please workflow file is also normalized to `.yaml`.

> ⚠️ **Prerequisite:** the org secret `RELEASE_PLEASE_APP_PRIVATE_KEY` must be visible to this (public) repo — set its visibility to **All repositories**. `RELEASE_PLEASE_APP_ID` is already set to all. Without this the `create-github-app-token` step fails.

Committed as `fix:` so merging this triggers release-please to cut the next release (validating the pipeline end to end).