### PR TITLE
ci: bring release-please config up to GlueOps convention

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,6 +1,64 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "include-component-in-tag": false,
+  "changelog-sections": [
+    {
+      "type": "feat",
+      "section": "Features"
+    },
+    {
+      "type": "fix",
+      "section": "Bug Fixes"
+    },
+    {
+      "type": "perf",
+      "section": "Performance Improvements"
+    },
+    {
+      "type": "revert",
+      "section": "Reverts"
+    },
+    {
+      "type": "docs",
+      "section": "Documentation",
+      "hidden": false
+    },
+    {
+      "type": "style",
+      "section": "Styles",
+      "hidden": false
+    },
+    {
+      "type": "chore",
+      "section": "Miscellaneous Chores",
+      "hidden": false
+    },
+    {
+      "type": "refactor",
+      "section": "Code Refactoring",
+      "hidden": false
+    },
+    {
+      "type": "test",
+      "section": "Tests",
+      "hidden": false
+    },
+    {
+      "type": "build",
+      "section": "Build System",
+      "hidden": false
+    },
+    {
+      "type": "ci",
+      "section": "Continuous Integration",
+      "hidden": false
+    },
+    {
+      "type": "deps",
+      "section": "Dependencies",
+      "hidden": false
+    }
+  ],
   "packages": {
     ".": {
       "release-type": "simple",


### PR DESCRIPTION
Brings the release-please setup up to the [GlueOps convention](https://github.com/GlueOps/skills).

**What changed**
- Add the full `changelog-sections` list to `release-please-config.json` so the changelog surfaces every Conventional-Commit type (chore/docs/ci/deps/etc.), not just feat/fix. This controls changelog *visibility* only — it does not change which commit types cut a release.

This is config-only; auth (public-release-please App), plain `vX.Y.Z` tags, and the seeded manifest were already on-convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)